### PR TITLE
(debian) depend on libpcap0.8-dev instead of transitional libpcap-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: moosefs
 Section: admin
 Priority: extra
 Maintainer: MooseFS Team <contact@moosefs.com>
-Build-Depends: debhelper (>= 7.0.15), autotools-dev, libc6-dev, libfuse-dev, pkg-config, zlib1g-dev, libpcap-dev, python (>= 2.5)
+Build-Depends: debhelper (>= 7.0.15), autotools-dev, libc6-dev, libfuse-dev, pkg-config, zlib1g-dev, libpcap0.8-dev, python (>= 2.5)
 Standards-Version: 3.7.3
 Homepage: http://moosefs.com/
 


### PR DESCRIPTION
libpcap-dev has been transitional since at least Debian wheezy. Probably will get removed soon.