### PR TITLE
fix fleng in finfo after truncate

### DIFF
--- a/mfsmount/mfs_fuse.c
+++ b/mfsmount/mfs_fuse.c
@@ -2058,6 +2058,12 @@ void mfs_setattr(fuse_req_t req, fuse_ino_t ino, struct stat *stbuf, int to_set,
 			fuse_reply_err(req, status);
 			return;
 		}
+		if (fi != NULL) {
+			finfo *fileinfo = finfo_get(fi->fh);
+			if (fileinfo != NULL && fileinfo->inode==ino) {
+				info->fleng = stbuf->st_size;
+			}
+		}
 		write_data_inode_setmaxfleng(ino,stbuf->st_size);
 		read_inode_set_length_sync(ino,stbuf->st_size,1);
 	}

--- a/mfsmount/mfs_fuse.c
+++ b/mfsmount/mfs_fuse.c
@@ -2058,12 +2058,7 @@ void mfs_setattr(fuse_req_t req, fuse_ino_t ino, struct stat *stbuf, int to_set,
 			fuse_reply_err(req, status);
 			return;
 		}
-		if (fi != NULL) {
-			finfo *fileinfo = finfo_get(fi->fh);
-			if (fileinfo != NULL && fileinfo->inode==ino) {
-				info->fleng = stbuf->st_size;
-			}
-		}
+		finfo_change_fleng(ino,stbuf->st_size);
 		write_data_inode_setmaxfleng(ino,stbuf->st_size);
 		read_inode_set_length_sync(ino,stbuf->st_size,1);
 	}


### PR DESCRIPTION
When a file is open as read/write, after truncate(), the finfo.fleng could be wrong, the following read() will use wrong fleng.