### PR TITLE
changing close_pipe() to close() calls to use regular POSIX functions.

### DIFF
--- a/mfsmount/readdata.c
+++ b/mfsmount/readdata.c
@@ -601,7 +601,7 @@ void* read_worker(void *arg) {
 //				fprintf(stderr,"close worker (avail:%"PRIu32" ; total:%"PRIu32")\n",workers_avail,workers_total);
 				read_data_close_worker(w);
 				zassert(pthread_mutex_unlock(&workers_lock));
-				close_pipe(pipefd);
+				close(pipefd);
 				return NULL;
 			}
 			zassert(pthread_mutex_unlock(&workers_lock));
@@ -617,7 +617,7 @@ void* read_worker(void *arg) {
 //			fprintf(stderr,"close worker (avail:%"PRIu32" ; total:%"PRIu32")\n",workers_avail,workers_total);
 			read_data_close_worker(w);
 			zassert(pthread_mutex_unlock(&workers_lock));
-			close_pipe(pipefd);
+			close(pipefd);
 			return NULL;
 		}
 

--- a/mfsmount/writedata.c
+++ b/mfsmount/writedata.c
@@ -679,7 +679,7 @@ void* write_worker(void *arg) {
 //				fprintf(stderr,"close worker (avail:%"PRIu32" ; total:%"PRIu32")\n",workers_avail,workers_total);
 				write_data_close_worker(w);
 				zassert(pthread_mutex_unlock(&workerslock));
-				close_pipe(pipefd);
+				close(pipefd);
 				return NULL;
 			}
 			zassert(pthread_mutex_unlock(&workerslock));
@@ -694,7 +694,7 @@ void* write_worker(void *arg) {
 		if (data==NULL) {
 			write_data_close_worker(w);
 			zassert(pthread_mutex_unlock(&workerslock));
-			close_pipe(pipefd);
+			close(pipefd);
 			return NULL;
 		}
 


### PR DESCRIPTION
close_pipe() is not available on my system, it's more robust to simply use close() that is a standard function able to close file descriptors.