### PR TITLE
fix hdd init do not load HDD_FSYNC_BEFORE_CLOSE configure item

### DIFF
--- a/mfschunkserver/hddspacemgr.c
+++ b/mfschunkserver/hddspacemgr.c
@@ -6643,6 +6643,7 @@ int hdd_init(void) {
 	if (HDDRebalancePerc>100) {
 		HDDRebalancePerc=100;
 	}
+	DoFsyncBeforeClose = cfg_getuint8("HDD_FSYNC_BEFORE_CLOSE",0);
 	Sparsification = cfg_getuint8("HDD_SPARSIFY_ON_WRITE",1);
 
 	main_reload_register(hdd_reload);


### PR DESCRIPTION
in hdd_init()， there is some configure item don't read, is this ok?