### PR TITLE
extend REPLICATIONS_RESPECT_TOPOLOGY behavior

### DIFF
--- a/mfsdata/mfsmaster.cfg.in
+++ b/mfsdata/mfsmaster.cfg.in
@@ -95,7 +95,12 @@
 # initial delay in seconds before starting replications (default is 60)
 # REPLICATIONS_DELAY_INIT = 60
 
-# whether to make undergoal replications respect topology (default is 0, i.e. no)
+# whether to make replications respect topology (default is 0, i.e. no)
+# All modes:
+#  0 - feature not enable, replications do not respect topology.
+#  1 - undergoal replications respect topology
+#  2 - undergoal replications respect topology, and only happens in same rack, if there're valid chunks in same rack, otherwise, undergoal replications across racks will happen.
+#  3 - undergoal replications respect topology, and force in same rack, which should be a temporary settings.
 # REPLICATIONS_RESPECT_TOPOLOGY = 0
 
 # Chunks loop shouldn't check more chunks per seconds than given number (default is 100000)

--- a/mfsmaster/topology.c
+++ b/mfsmaster/topology.c
@@ -37,6 +37,7 @@
 #include "cfg.h"
 #include "slogger.h"
 #include "massert.h"
+#include "topology.h"
 
 static void *racktree;
 static char *TopologyFileName;
@@ -198,7 +199,7 @@ int topology_parsenet(char *net,uint32_t *fromip,uint32_t *toip) {
 // as for now:
 //
 // 0 - same machine
-// 1 - same rack, different machines
+// 1 - same rack, different machines, also defined as TOPOLOGY_SAME_RACK_DISTANCE
 // 2 - different racks
 
 uint8_t topology_distance(uint32_t ip1,uint32_t ip2) {
@@ -219,7 +220,7 @@ uint8_t topology_distance(uint32_t ip1,uint32_t ip2) {
 //		rid1>>=1;
 //	}
 //	return rid2;
-	return (rid1==rid2)?1:2;
+	return (rid1==rid2)?TOPOLOGY_SAME_RACK_DISTANCE:2;
 }
 
 // format:

--- a/mfsmaster/topology.h
+++ b/mfsmaster/topology.h
@@ -23,6 +23,8 @@
 
 #include <inttypes.h>
 
+#define TOPOLOGY_SAME_RACK_DISTANCE 1
+
 uint8_t topology_distance(uint32_t ip1,uint32_t ip2);
 int topology_init(void);
 


### PR DESCRIPTION
I'm doing the migration of moosefs chunks between IDCs. After one chunk have been replicated to the target IDC, then I need to replicate the one chunk to more copies to satisfy the goal - I want the replication happen in the the target IDC, so I can reduce the flow bandwidth between IDCs.

So I extend the behavior of REPLICATIONS_RESPECT_TOPOLOGY (introduced by https://github.com/moosefs/moosefs/pull/105)

All modes:
 0 - feature not enable, replications do not respect topology.
 1 - undergoal replications respect topology
 2 - undergoal replications respect topology, and only happens in same rack, if there're valid chunks in same rack, otherwise, undergoal replications across racks will happen.
 3 - undergoal replications respect topology, and force in same rack, which should be a temporary settings.