### PR TITLE
mfsclient/mfsio: include sys/file.h for LOCK_* functions

### DIFF
--- a/mfsclient/mfsio.c
+++ b/mfsclient/mfsio.c
@@ -31,6 +31,9 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <pthread.h>
+#ifdef HAVE_SYS_FILE_H
+#include <sys/file.h>
+#endif
 
 #include "MFSCommunication.h"
 #include "mastercomm.h"


### PR DESCRIPTION
### Motivation and Context

Fixes compilation on musl libc systems

### Description

Include sys/file.h for the LOCK_* functions
<!--- Describe your changes in detail -->

### How Has This Been Tested?

Tested compilation against musl libc systems on x86_64-musl, armv7l-musl and aarch64-musl

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions). -->
- [ ] I have updated the documentation accordingly.
<!--- - [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md). -->
- [ ] I have added [tests](https://github.com/moosefs/moosefs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
<!--- - [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by). -->

<!---
This PULL_REQUEST_TEMPLATE.md was shamelessly stolen from from https://github.com/zfsonlinux/zfs

As MooseFS evolves it should adopt contribution guidelines and work with the community on an extensive set of tests.
-->
