### PR TITLE
Fix #151, mfsmaster.8

### DIFF
--- a/mfsmanpages/mfsmaster.8
+++ b/mfsmanpages/mfsmaster.8
@@ -40,7 +40,7 @@ run in foreground, don't daemonize
 how long to wait for lockfile (in seconds; default is 1800 seconds)
 .TP
 \fB\-i\fP
-ignore some metadata structure errors
+ignore some metadata structure errors (attach orphans to root, ignore names without inode, etc.). DO NOT use unless you are ready to pick up the pieces. See https://github.com/moosefs/moosefs/issues/151 for discussion.
 .TP
 \fB\-a\fP
 automatically restore metadata from change logs


### PR DESCRIPTION
### Motivation and Context

Resolve #151 : 

1.  `mfsmaster -h` and `man mfsmaster` show the same explanation of what can happen when metadata structure errors are ignored when running with `-i`.

2. Make it explicit that ignoring errors in metadata structures is not a magic wand, and could possibly lead to a messy situation.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)