### PR TITLE
gettimeofday encapsulated in the function gettimeofday_usec

### DIFF
--- a/mfsclient/mastercomm.c
+++ b/mfsclient/mastercomm.c
@@ -1039,10 +1039,7 @@ const uint8_t* fs_sendandreceive(threc *rec,uint32_t expected_cmd,uint32_t *answ
 					return NULL;
 				}
 				period = usectimeout - period;
-				gettimeofday(&tv, NULL);
-				usecto = tv.tv_sec;
-				usecto *= 1000000;
-				usecto += tv.tv_usec;
+                usecto = gettimeofday_usec(&tv);
 				usecto += period;
 				ts.tv_sec = usecto / 1000000;
 				ts.tv_nsec = (usecto % 1000000) * 1000;
@@ -1176,10 +1173,7 @@ const uint8_t* fs_sendandreceive_any(threc *rec,uint32_t *received_cmd,uint32_t 
 					return NULL;
 				}
 				period = usectimeout - period;
-				gettimeofday(&tv, NULL);
-				usecto = tv.tv_sec;
-				usecto *= 1000000;
-				usecto += tv.tv_usec;
+				usecto = gettimeofday_usec(&tv);
 				usecto += period;
 				ts.tv_sec = usecto / 1000000;
 				ts.tv_nsec = (usecto % 1000000) * 1000;
@@ -2400,10 +2394,7 @@ void* fs_receive_thread(void *arg) {
 					rusectime += usecping/2;
 					// usectime here should have master's wall clock
 					fs_amtime_reference_clock(usec,rusectime);
-					gettimeofday(&tv,NULL);
-					lusectime = tv.tv_sec;
-					lusectime *= 1000000;
-					lusectime += tv.tv_usec;
+					lusectime = gettimeofday_usec(&tv);
 					if (rusectime + 1000000 < lusectime || lusectime + 1000000 < rusectime) {
 						syslog(LOG_WARNING,"time desync between client and master is higher than a second - it might lead to strange atime/mtime behaviour - consider time synchronization in your moosefs cluster");
 					}
@@ -2545,10 +2536,7 @@ void fs_init_threads(uint32_t retries,uint32_t timeout) {
 	af_lruhead = NULL;
 	af_lrutail = &(af_lruhead);
 	af_lru_cnt = 0;
-	gettimeofday(&tv,NULL);
-	usectime = tv.tv_sec;
-	usectime *= 1000000;
-	usectime += tv.tv_usec;
+	usectime = gettimeofday_usec(&tv);
 	timediffusec = usectime - monotonic_useconds(); // before receiving packets from master start with own wall clock
 	zassert(pthread_key_create(&reckey,fs_free_threc));
 	zassert(pthread_mutex_init(&reclock,NULL));

--- a/mfsclient/mastercomm.c
+++ b/mfsclient/mastercomm.c
@@ -1039,7 +1039,7 @@ const uint8_t* fs_sendandreceive(threc *rec,uint32_t expected_cmd,uint32_t *answ
 					return NULL;
 				}
 				period = usectimeout - period;
-                usecto = gettimeofday_usec(&tv);
+				usecto = gettimeofday_usec(&tv);
 				usecto += period;
 				ts.tv_sec = usecto / 1000000;
 				ts.tv_nsec = (usecto % 1000000) * 1000;

--- a/mfsclient/readdata.c
+++ b/mfsclient/readdata.c
@@ -1994,10 +1994,7 @@ int read_data(void *vid, uint64_t offset, uint32_t *size, void **vrhead,struct i
 					struct timespec ts;
 					struct timeval tv;
 					uint64_t usecto;
-					gettimeofday(&tv, NULL);
-					usecto = tv.tv_sec;
-					usecto *= 1000000;
-					usecto += tv.tv_usec;
+					usecto = gettimeofday_usec(&tv);
 					usecto += usectimeout;
 					ts.tv_sec = usecto / 1000000;
 					ts.tv_nsec = (usecto % 1000000) * 1000;

--- a/mfscommon/clocks.c
+++ b/mfscommon/clocks.c
@@ -48,6 +48,11 @@
 
 #include <inttypes.h>
 
+uint64_t gettimeofday_usec(struct timeval *tv) {
+	gettimeofday(tv, NULL);
+	return (uint64_t) (tv->tv_sec * UINT64_C(1000000)) + (uint64_t) tv->tv_usec;
+}
+
 #if defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_MONOTONIC)
 double monotonic_seconds() {
 	struct timespec ts;

--- a/mfscommon/clocks.h
+++ b/mfscommon/clocks.h
@@ -22,6 +22,9 @@
 #define _CLOCKS_H_
 
 #include <inttypes.h>
+#include <sys/time.h>
+
+uint64_t gettimeofday_usec(struct timeval *tv);
 
 double monotonic_seconds();
 uint64_t monotonic_useconds();

--- a/mfscommon/cpuusage.c
+++ b/mfscommon/cpuusage.c
@@ -61,6 +61,7 @@
 
 #include <stdlib.h>
 #include <inttypes.h>
+#include <clocks.h>
 // #include <syslog.h>
 
 #if defined(HAVE_SETITIMER)
@@ -87,10 +88,7 @@ void cpu_init (void) {
 #endif
 
 #if defined(HAVE_GETTIMEOFDAY)
-	gettimeofday(&tod,NULL);
-	lastget = tod.tv_sec;
-	lastget *= UINT64_C(1000000);
-	lastget += tod.tv_usec;
+	lastget = gettimeofday_usec(&tod);
 #else
 	lastget = time(NULL);
 	lastget *= UINT64_C(1000000);
@@ -137,10 +135,7 @@ void cpu_used (uint64_t *scpu,uint64_t *ucpu) {
 	uint64_t systime,usertime;
 
 #if defined(HAVE_GETTIMEOFDAY)
-	gettimeofday(&tod,NULL);
-	now = tod.tv_sec;
-	now *= UINT64_C(1000000);
-	now += tod.tv_usec;
+	now = gettimeofday_usec(&tod);
 #else
 	now = time(NULL);
 	now *= UINT64_C(1000000);

--- a/mfscommon/main.c
+++ b/mfscommon/main.c
@@ -426,11 +426,8 @@ void main_keep_alive(void) {
 	struct timeval tv;
 	kaentry *kait;
 
-	gettimeofday(&tv,NULL);
 	useclast = usecnow;
-	usecnow = tv.tv_sec;
-	usecnow *= 1000000;
-	usecnow += tv.tv_usec;
+	usecnow = gettimeofday_usec(&tv);
 	now = tv.tv_sec;
 	if (usecnow>useclast && useclast>0) {
 		useclast = usecnow - useclast;
@@ -473,11 +470,8 @@ void mainloop() {
 			pollit->desc(pdesc,&ndesc);
 		}
 		i = poll(pdesc,ndesc,10);
-		gettimeofday(&tv,NULL);
 		useclast = usecnow;
-		usecnow = tv.tv_sec;
-		usecnow *= 1000000;
-		usecnow += tv.tv_usec;
+		usecnow = gettimeofday_usec(&tv);
 		now = tv.tv_sec;
 		if (usecnow>useclast && useclast>0) {
 			useclast = usecnow - useclast;

--- a/mfsmaster/matoclserv.c
+++ b/mfsmaster/matoclserv.c
@@ -1794,10 +1794,7 @@ void matoclserv_fuse_time_sync(matoclserventry *eptr,const uint8_t *data,uint32_
 		msgid = 0;
 	}
 
-	gettimeofday(&tv,NULL);
-	usectime = tv.tv_sec;
-	usectime *= 1000000;
-	usectime += tv.tv_usec;
+	usectime = gettimeofday_usec(&tv);
 
 	ptr = matoclserv_createpacket(eptr,MATOCL_FUSE_TIME_SYNC,8+length);
 	if (length==4) {


### PR DESCRIPTION
Several calls to gettimeofday have been encapsulated in a gettimeofday_used function located in mfscommon/clocks.c
