### PR TITLE
Fix typo in log messages

### DIFF
--- a/mfscommon/main.c
+++ b/mfscommon/main.c
@@ -1666,7 +1666,7 @@ int main(int argc,char **argv) {
 		}
 		ch=1;
 	}
-	mfs_syslog(LOG_NOTICE,"exititng ...");
+	mfs_syslog(LOG_NOTICE,"exiting ...");
 	destruct();
 	free_all_registered_entries();
 	signal_cleanup();


### PR DESCRIPTION
"exititng" should be "exiting" :)

### Motivation and Context
There is a typo in the logging for the chunkserver.

### Description
Simple typo fix.

### How Has This Been Tested?
Let's be honest, it hasn't.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [X] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions). -->
- [X] I have updated the documentation accordingly.
<!--- - [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md). -->
- [] I have added [tests](https://github.com/moosefs/moosefs/tree/master/tests) to cover my changes.
- [] All new and existing tests passed.
<!--- - [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by). -->

<!---
This PULL_REQUEST_TEMPLATE.md was shamelessly stolen from from https://github.com/zfsonlinux/zfs

As MooseFS evolves it should adopt contribution guidelines and work with the community on an extensive set of tests.
-->
