### PR TITLE
(manpages) fix minor typo ("changign" -> "changing")

### DIFF
--- a/mfsmanpages/mfschunkserver.cfg.5
+++ b/mfsmanpages/mfschunkserver.cfg.5
@@ -82,7 +82,7 @@ enables/disables sparsification (skip leading and trailing zeros) during writing
 how many chunks should be created in one directory before moving to the next one; higher values are better with most OSes caching algorithms, low values lead to more even chunk distribution; default is 10000 which works best in most cases
 .TP
 .B HDD_KEEP_DUPLICATES_HOURS
-how many hours duplicate chunks should be kept before deleting (default is 168 - one week); changign this value and reloading will reset the counter
+how many hours duplicate chunks should be kept before deleting (default is 168 - one week); changing this value and reloading will reset the counter
 .TP
 .B ALLOW_STARTING_WITH_INVALID_DISKS
 when set to one chunkserver will not abort start even when incorrect entries are found in 'mfshdd.cfg' file; default is 0 (do not start with invalid entries)


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions). -->
- [x] I have updated the documentation accordingly.
<!--- - [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md). -->
- [ ] ~~I have added [tests](https://github.com/moosefs/moosefs/tree/master/tests) to cover my changes.~~
- [ ] ~~All new and existing tests passed.~~
<!--- - [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by). -->

<!---
This PULL_REQUEST_TEMPLATE.md was shamelessly stolen from from https://github.com/zfsonlinux/zfs

As MooseFS evolves it should adopt contribution guidelines and work with the community on an extensive set of tests.
-->
