### PR TITLE
(manpages) update "HDD_LEAVE_SPACE_DEFAULT" regex to escape "."

### DIFF
--- a/mfsdata/mfschunkserver.cfg.in
+++ b/mfsdata/mfschunkserver.cfg.in
@@ -43,7 +43,7 @@
 # HDD_FADVISE_MIN_TIME = 86400
 
 # how much space should be left unused on each hard drive (default: 256MiB)
-# number format: [0-9]*(.[0-9]*)?([kMGTPE]|[KMGTPE]i)?B?
+# number format: [0-9]*([.][0-9]*)?([kMGTPE]|[KMGTPE]i)?B?
 # examples: 0.5GB ; .5G ; 2.56GiB ; 1256M etc.
 # HDD_LEAVE_SPACE_DEFAULT = 256MiB
 

--- a/mfsmanpages/mfschunkserver.cfg.5
+++ b/mfsmanpages/mfschunkserver.cfg.5
@@ -60,7 +60,7 @@ s that support posix_fadivise; default value is 86400
 .TP
 .B HDD_LEAVE_SPACE_DEFAULT
 how much space should be left unused on each hard drive; 
-number format: [0-9]*(.[0-9]*)?([kMGTPE]|[KMGTPE]i)?B? ; default is 256MiB; 
+number format: [0-9]*([.][0-9]*)?([kMGTPE]|[KMGTPE]i)?B? ; default is 256MiB; 
 examples: 0.5GB, .5G, 2.56GiB, 1256M etc.
 .TP
 .B HDD_REBALANCE_UTILIZATION


### PR DESCRIPTION
Normally I would've combined this with https://github.com/moosefs/moosefs/pull/568 (caught them during the same reading), but I think this one is possibly slightly more controversial? :sweat_smile:

This string in the documentation looks like a regular expression, which makes the unescaped `.` in it feel odd.  I went for the "idiomatic Perl" style `[.]` escaping because I personally find it more readable, but I'm happy to swap to the more common `\.` or even just have the PR closed instead because I don't feel strongly about it at all. :smile:

(I also double checked that the code wasn't actually using a regular expression that needed to be updated, and indeed confirmed that it has some code that does parsing and something like `c == '.'` for testing this case and the regex is purely documentation. :+1:)