### PR TITLE
(cli) fixed "chuks" typo in "regularchuks" json mode key

### DIFF
--- a/mfsscripts/mfscli.py.in
+++ b/mfsscripts/mfscli.py.in
@@ -4729,7 +4729,7 @@ if "IN" in sectionset:
 				elif jsonmode:
 					json_ic_dict = {}
 					json_ic_sum_dict = {}
-					matrixkeys = ['allchunks','regularchuks','allchunks_copies','regularchunks_copies','allchunks_ec8','regularchunks_ec8','allchunks_ec4', 'regularchunks_ec4']
+					matrixkeys = ['allchunks','regularchunks','allchunks_copies','regularchunks_copies','allchunks_ec8','regularchunks_ec8','allchunks_ec4', 'regularchunks_ec4']
 					sumkeys = ['missing','endangered','undergoal','stable','overgoal','pending_deletion','ready_to_remove']
 					#sumlist has to be clean for JSON mode
 					sumlist = []


### PR DESCRIPTION
As far as I can find, this is the only instance of `chuks` anywhere in the entire codebase, so it _must_ be a typo. :sweat_smile: