### PR TITLE
fix order of operations during multilan init

### DIFF
--- a/mfsmaster/multilan.c
+++ b/mfsmaster/multilan.c
@@ -265,9 +265,10 @@ void multilan_reload (void) {
 }
 
 int multilan_init(void) {
+	int err = csipmap_init();
 	multilan_reload();
 
 	main_reload_register(multilan_reload);
 	main_destruct_register(multilan_term);
-	return csipmap_init();
+	return err;
 }


### PR DESCRIPTION
Currently, the IP Mapping feature is broken due to calling the csipmap_init() function late after the map config was already read. This causes mooseFS to not find any mappings during runtime

### Motivation and Context
Issue #649 

### Description
within multilan_init() I moved the call to csipmap_init() to the beginning of the function rather than the end, since IPMAP loading happens during multilan_reload().

### How Has This Been Tested?
Tested on my own setup with a single mfsmaster that is on a VPN network with the chunkserver and the client. the client is also in direct LAN with the chunkserver. The fix was compiled and deployed and I tried streaming a video file from my existing MFS mount. Before the fix, the connection would be made via VPN even though the mfsipmap.cfg file was configured to use LAN IP. After the fix the stream was consumed from LAN as expected. the issue is described in detail in the issue ticket that I opened

This shouldn't affect any other part of code, the csipmap_init() function is pretty simple and benign, only setting global structures and values to NULL.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions). -->
- [x] I have updated the documentation accordingly.
<!--- - [ x I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md). -->
- [x] I have added [tests](https://github.com/moosefs/moosefs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
<!--- - [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by). -->

<!---
This PULL_REQUEST_TEMPLATE.md was shamelessly stolen from from https://github.com/zfsonlinux/zfs

As MooseFS evolves it should adopt contribution guidelines and work with the community on an extensive set of tests.
-->