### PR TITLE
(cs) fix may be used uninitialized warning

### DIFF
--- a/mfschunkserver/hddspacemgr.c
+++ b/mfschunkserver/hddspacemgr.c
@@ -6594,6 +6594,8 @@ static inline int hdd_rebalance_find_servers(folder **fsrc,folder **fdst,uint8_t
 	// check REBALANCE_FORCE_SRC and REBALANCE_FORCE_DST
 	abovecnt = 0;
 	belowcnt = 0;
+	abovesum = 0;
+	belowsum = 0;
 	avgcount = 0;
 	*changed = 0;
 	for (f=folderhead ; f ; f=f->next) {


### PR DESCRIPTION
### Motivation and Context

Compilation warnings under Alpine Linux with gcc version 14.2.0

### Description

Compilation warnings:
```
hddspacemgr.c: In function 'hdd_rebalance_find_servers': hddspacemgr.c:6770:12: warning: 'abovesum' may be used uninitialized in this function [-Wmaybe-uninitialized]
 6770 |    expdist = abovesum;
      |    ~~~~~~~~^~~~~~~~~~
hddspacemgr.c:6780:13: warning: 'belowsum' may be used uninitialized in this function [-Wmaybe-uninitialized]
 6780 |     expdist = belowsum;
      |     ~~~~~~~~^~~~~~~~~~
```

### How Has This Been Tested?

Apply patch to existing code and use in production environment.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)