### PR TITLE
(mfsclient) add FUSE-over-io_uring support (libfuse 3.18+)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -593,9 +593,24 @@ fi
 
 AM_CONDITIONAL([WITH_BDEV], [test "$bdev" != "no" -a "$enable_mfsbdev" != "no"])
 
+AC_ARG_ENABLE([io-uring],
+	AS_HELP_STRING([--disable-io-uring],
+		[disable FUSE-over-io_uring support even when libfuse >= 3.18 is present]),
+	[],
+	[enable_io_uring=yes])
+
 if test "$fuse" != "no" -a "enable_mfsmount" != "no"; then
 	if test -n "$PKG_CONFIG"; then
 		PKG_CHECK_MODULES([FUSE], [fuse3 >= 3.2.1], [AC_DEFINE([HAVE_FUSE3],[1],[libfuse3 detected])] , [ PKG_CHECK_MODULES([FUSE], [fuse >= 2.6], , [fuse=no]) ])
+		# FUSE-over-io_uring requires libfuse >= 3.18.0 at build time
+		# and Linux >= 6.7 with CONFIG_FUSE_IO_URING=y at run time. The
+		# capability is negotiated automatically by libfuse; HAVE_FUSE3_URING
+		# just gates the explicit conn->want |= FUSE_CAP_OVER_IO_URING in
+		# mfs_fsinit and the -o mfsnouring escape hatch.
+		if test "$enable_io_uring" != "no"; then
+			PKG_CHECK_EXISTS([fuse3 >= 3.18.0],
+				[AC_DEFINE([HAVE_FUSE3_URING],[1],[libfuse >= 3.18 with FUSE-over-io_uring support])])
+		fi
 	else
 		echo "no pkg-config - can't check FUSE version"
 		fuse=no

--- a/mfsclient/mfsmount.c
+++ b/mfsclient/mfsmount.c
@@ -224,6 +224,7 @@ struct mfsopts {
 	int noxattrs;
 	int noposixlocks;
 	int nobsdlocks;
+	int nouring;
 	int donotrememberpassword;
 //	int xattraclsupport;
 	unsigned writecachesize;
@@ -324,6 +325,7 @@ static struct fuse_opt mfs_opts_stage2[] = {
 	MFS_OPT("mfsnoposixlocks", noposixlocks, 1),
 	MFS_OPT("mfsnobsdlock", nobsdlocks, 1),
 	MFS_OPT("mfsnobsdlocks", nobsdlocks, 1),
+	MFS_OPT("mfsnouring", nouring, 1),
 	MFS_OPT("mfscachemode=%s", cachemode, 0),
 	MFS_OPT("mfsmkdircopysgid=%u", mkdircopysgid, 0),
 	MFS_OPT("mfssugidclearmode=%s", sugidclearmodestr, 0),
@@ -463,6 +465,9 @@ static void usage(const char *progname) {
 #endif
 #if FUSE_VERSION >= 29
 	fprintf(fd,"    -o mfsnobsdlocks            turn off support for global BSD locks (flock) - locks will work locally\n");
+#endif
+#ifdef HAVE_FUSE3_URING
+	fprintf(fd,"    -o mfsnouring               turn off FUSE-over-io_uring even when libfuse and kernel both support it\n");
 #endif
 	fprintf(fd,"\n");
 	fprintf(fd,"CMODE can be set to:\n");
@@ -779,6 +784,18 @@ static void mfs_fsinit (void *userdata, struct fuse_conn_info *conn) {
 		conn->want &= ~FUSE_CAP_POSIX_LOCKS;
 	}
 #endif
+// FUSE-over-io_uring (libfuse >= 3.18 + Linux >= 6.7 with CONFIG_FUSE_IO_URING=y)
+// libfuse defaults this capability on, but we state it explicitly to match the
+// negotiation pattern used for the other capabilities in this block, and to give
+// the -o mfsnouring escape hatch a single place to clear. If a future libfuse
+// renames the cap or relocates the activation point, search for FUSE_CAP_OVER_IO_URING.
+#if defined(HAVE_FUSE3_URING) && defined(FUSE_CAP_OVER_IO_URING)
+	if (mfsopts.nouring==0) {
+		conn->want |= FUSE_CAP_OVER_IO_URING;
+	} else {
+		conn->want &= ~FUSE_CAP_OVER_IO_URING;
+	}
+#endif
 	conn->want &= conn->capable; // we don't want to request things that kernel can't do
 //	conn->max_background - leave default
 //	conn->congestion_threshold - leave default
@@ -951,6 +968,7 @@ uint32_t main_snprint_parameters(char *buff,uint32_t size) {
 	BOOLOPT("mfsnoxattrs",noxattrs);
 	BOOLOPT("mfsnoposixlocks",noposixlocks);
 	BOOLOPT("mfsnobsdlocks",nobsdlocks);
+	BOOLOPT("mfsnouring",nouring);
 	NUMOPT("mfsmkdircopysgid","u",mkdircopysgid);
 	NUMOPT("mfsreaddirplusminto",".3lf",readdirplusminto);
 	NUMOPT("mfsattrcacheto",".3lf",attrcacheto);
@@ -1012,6 +1030,9 @@ uint32_t main_snprint_parameters(char *buff,uint32_t size) {
 		bprintf("kernel_capability_mask: 0x%"PRIX32"\n",fuse_capable);
 		bprintf("kernel_defaults_mask: 0x%"PRIX32"\n",fuse_defaults);
 		bprintf("kernel_working_mask: 0x%"PRIX32"\n",fuse_want);
+#if defined(HAVE_FUSE3_URING) && defined(FUSE_CAP_OVER_IO_URING)
+		bprintf("io_uring: %s\n",(fuse_want & FUSE_CAP_OVER_IO_URING)?"yes":"no");
+#endif
 #endif
 	}
 	return leng;
@@ -1782,6 +1803,7 @@ int main(int argc, char *argv[]) {
 	mfsopts.noxattrs = 0;
 	mfsopts.noposixlocks = 0;
 	mfsopts.nobsdlocks = 0;
+	mfsopts.nouring = 0;
 	mfsopts.cachemode = NULL;
 	mfsopts.writecachesize = 0;
 	mfsopts.readaheadsize = 0;

--- a/mfsmanpages/mfsmount.8
+++ b/mfsmanpages/mfsmount.8
@@ -187,6 +187,9 @@ turn off support for global posix locks (lockf + ioctl) - locks will work locall
 .TP
 \fB\-o mfsnobsdlocks\fP
 turn off support for global BSD locks (flock) - locks will work locally
+.TP
+\fB\-o mfsnouring\fP
+turn off FUSE-over-io_uring even when libfuse and kernel both support it. FUSE-over-io_uring is auto-enabled when built against libfuse >= 3.18 and running on Linux >= 6.7 with CONFIG_FUSE_IO_URING=y; use this option to force-disable at run time without rebuilding or downgrading libfuse.
 .SS MOUNT OPTIONS
 .PP
 General mount options (see \fBmount\fP\|(8) manual):


### PR DESCRIPTION
G'day MooseFS team,

Following up on my recent email to support (ticket **#8786**) — and answering my own question 3 ("would you be open to adding it?") by sending the patch your way. Hope this is helpful; happy to iterate on whatever shape you'd prefer it in.

### Motivation and Context

Linux 6.7 (December 2023) introduced `FUSE_OVER_IO_URING`, which serves the FUSE protocol over io_uring rings instead of `read()`/`write()` on `/dev/fuse`. libfuse 3.18 (2025-12-18) added the userspace API to take advantage of it.

The dominant per-operation cost in `mfsmount` today is the per-request `/dev/fuse` round-trip plus libfuse's bounce-buffer copies. FUSE-over-io_uring eliminates exactly that. Upstream measurements ([LWN article 932079](https://lwn.net/Articles/932079/)) show ~4× file-create throughput on metadata-heavy workloads — particularly relevant for AI/ML model-loading patterns (many small reads, lots of `stat()`s), which is central to how we use MooseFS at Runpod.

Looking at MooseFS 4.59.1 today, the client is not yet set up to use it:

- `mfsclient/fusecommon.h:8-12` pins `FUSE_USE_VERSION 34` (libfuse 3.0 baseline).
- `configure.ac:598` requires only `fuse3 >= 3.2.1`.
- `mfsclient/mfsmount.c:1416-1429` selects between `fuse_session_loop_mt` and `fuse_session_loop` without an io_uring branch.
- Tree-wide grep for `io_uring`, `liburing`, `IORING_`, `fuse_session_loop_uring` returns zero hits.

This PR addresses that.

### Description

The change is deliberately small and additive:

1. **`configure.ac`**:
   - Adds `--disable-io-uring` flag (default enabled).
   - When fuse3 ≥ 3.18 is detected via `PKG_CHECK_EXISTS`, defines `HAVE_FUSE3_URING`. **The hard libfuse minimum stays at 3.2.1** — builds against older libfuse continue to work, just without io_uring.

2. **`mfsclient/mfsmount.c`** (`mfs_fsinit` capability negotiation):
   - Explicitly handles `FUSE_CAP_OVER_IO_URING` in the same pattern used for `FUSE_CAP_FLOCK_LOCKS` and `FUSE_CAP_POSIX_LOCKS`. libfuse defaults the capability on, but stating it explicitly matches the negotiation idiom used for the other capabilities in this block and gives the new mount option a single place to clear it.

3. **`mfsclient/mfsmount.c`** (mount option, plumbed through the existing `mfsopts` struct + `MFS_OPT` + `BOOLOPT` + default-init pattern, alongside `mfsnobsdlocks` / `mfsnoposixlocks`):
   - `-o mfsnouring` — runtime escape hatch to force-disable FUSE-over-io_uring without rebuilding or downgrading libfuse. Mirrors the existing negative-opt-out style.

4. **`mfsclient/mfsmount.c`** (startup log near `kernel_working_mask`):
   - Adds `io_uring: yes`/`no` so operators don't have to decode bit `FUSE_CAP_OVER_IO_URING` (`1<<31`) from the hex mask.

5. **`mfsmanpages/mfsmount.8`**:
   - Documents `-o mfsnouring` and the auto-activation conditions (kernel ≥ 6.7 with `CONFIG_FUSE_IO_URING=y` + libfuse ≥ 3.18).

Total diff: 3 files, 40 lines.

### What this PR does NOT do

- **No FUSE_USE_VERSION bump.** Not needed — `FUSE_CAP_OVER_IO_URING` is exposed unconditionally in libfuse's `fuse_common.h:513`.
- **No new function call.** `fuse_session_loop_mt()` handles io_uring internally in libfuse 3.18+; no new entry point is required.
- **No hard libfuse version bump.** `configure.ac`'s `fuse3 >= 3.2.1` minimum is unchanged so older-distro builds keep working.
- **No NEWS entry** — left for you to fold in on release per the existing convention.

### How has this been tested?

- **Builds clean against libfuse 3.18.2** — `autoreconf -fi && ./configure --disable-mfsmaster --disable-mfsmetalogger --disable-mfschunkserver --disable-mfsgui --disable-mfsnetdump --disable-mfsbdev && make` on NixOS.
- **Regression build clean** — the same toolchain with `./configure --disable-io-uring` produces a `mfsmount` binary identical in `--help` output to the unmodified upstream tree, confirming the preprocessor gates are fully effective.
- **`mfsmount --help` shows `-o mfsnouring`** when built against fuse3 ≥ 3.18, and does NOT show it when built with `--disable-io-uring` (correct behavior).
- **Static analysis** — built a small Nix flake with baseline-anomaly gating across clang-tidy / cppcheck / flawfinder / GCC pedantic-warnings (`-Wpedantic -Wshadow -Wcast-qual -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wnull-dereference -Wdouble-promotion -Wfloat-equal -Walloca -Wvla -Werror=return-type -Werror=format-security`, etc.) against unmodified `master` and re-ran on this patched tree. **Result: zero new categories of findings introduced.** The only semantic difference detected is `main_snprint_parameters`' cognitive complexity ticking from 231 to 239 (the function was already 9× over clang-tidy's threshold of 25 — pre-existing structural issue, not a regression introduced by the patch).
- **Runtime verification deferred** — we don't have a complete single-node MooseFS-Pro test cluster wired up locally yet; we can verify io_uring activation via `mfsmount`'s new `io_uring: yes` startup log line and the `kernel_working_mask` bit. Happy to run a follow-up benchmark against a representative workload on our cluster once this lands.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist

- [x] I have updated the documentation accordingly (`mfsmanpages/mfsmount.8` documents the new option).
- [ ] I have added tests to cover my changes (MooseFS's test framework expects a real cluster; happy to add one if you'd like — guidance welcome).
- [x] All new and existing tests passed (the existing test suite is unchanged; static analysis baseline gates were green pre- and post-patch with no new finding categories).

### Closing

Two things worth flagging for your review judgement, in case either changes how you'd prefer this shaped:

1. The `-o mfsnouring` option overlaps slightly with libfuse 3.18's own built-in `-o io_uring` / `-o io_uring_q_depth=N` options. They're at different abstraction layers — libfuse's toggle, our toggle clears `conn->want` so MooseFS's own negotiation reflects intent — but if you'd prefer to drop the MooseFS-level option in favor of leaving io_uring solely under libfuse's control, that's a one-block delete.
2. We optimized for "additive, easy to review" over "shortest possible diff." A truly minimal version is ~10 lines (just the `configure.ac` detect + an `#ifdef HAVE_FUSE3_URING` block in `mfs_fsinit`). Happy to slim this down if that fits your style better.

Thanks for the great project. Looking forward to your thoughts.

Dave Seddon
Runpod
